### PR TITLE
Win64 fixes to allow testing more than 4GB video memory

### DIFF
--- a/Makefiles/Makefile.windows
+++ b/Makefiles/Makefile.windows
@@ -1,4 +1,7 @@
-OPENCL_VENDOR=NV # NV, NV64, AMD, AMD64
+#build from Native 64 bit tools command prompt in the project root with
+#nmake -f Makefiles\Makefile.windows
+#Building with NV64 vendor can provide binary that at runtime works fine on both amd, nvidia and intel
+OPENCL_VENDOR=NV64 # NV, NV64, AMD, AMD64
 
 !if "$(OPENCL_VENDOR)" == "NV"
 OPENCL_DIR="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v5.5"
@@ -7,7 +10,7 @@ OPENCL_LIB=$(OPENCL_DIR)\lib\Win32\OpenCL.lib
 !endif
 
 !if "$(OPENCL_VENDOR)" == "NV64"
-OPENCL_DIR="\CUDA"
+OPENCL_DIR="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v8.0"
 OPENCL_INC=$(OPENCL_DIR)\include
 OPENCL_LIB=$(OPENCL_DIR)\lib\x64\OpenCL.lib
 !endif

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ or -l options:
     memtestcl -l
 ```
 
+To check lots of memory on AMD cards extra environment variables can be useful,
+depending on the driver version. For example with the below settings testing
+7672MB was succesfully done on a 8GB AMD gpu w/o display on 64-bit windows.
+```
+    set GPU_MAX_HEAP_SIZE=100
+    set GPU_SINGLE_ALLOC_PERCENT=100
+    set GPU_ENABLE_LARGE_ALLOCATION=1
+
+```
+
 ## Frequently Asked Questions
 
 - I have an {ATI 2xxx/3xxx ,NVIDIA 5/6/7-series} video card and it doesn't work!

--- a/memtestCL_core.cpp
+++ b/memtestCL_core.cpp
@@ -139,7 +139,7 @@ uint memtestState::allocate(uint mbToTest) {
 		cl_int err;
 		try {
             // AMD's OpenCL will throw an error on allocation, NVIDIA on use. So both alloc and try to init.
-            devTestMem = clCreateBuffer(ctx,CL_MEM_READ_WRITE,megsToTest*1048576UL,NULL,&err);
+            devTestMem = clCreateBuffer(ctx,CL_MEM_READ_WRITE,megsToTest*1048576ULL,NULL,&err);
             if (err != CL_SUCCESS) {
                 cerr << "Unable to allocate OpenCL memory: "<<descriptionOfError(err)<<endl;
                 throw 1;
@@ -192,7 +192,7 @@ bool memtestState::gpuMemoryBandwidth(double& bandwidth,uint mbToTest,uint iters
     
     uint start = getTimeMilliseconds();
     for (uint i = 0; i < iters; i++) {
-        err = clEnqueueCopyBuffer(cq,devTestMem,devTestMem,0,mbToTest*1048576UL,mbToTest*1048576UL,0,NULL,events+i);
+        err = clEnqueueCopyBuffer(cq,devTestMem,devTestMem,0,mbToTest*1048576ULL,mbToTest*1048576ULL,0,NULL,events+i);
         if (err != CL_SUCCESS) {
             cerr << "Status of clEnqueueCopyBuffer was "<<descriptionOfError(err)<<endl;
             return false;


### PR DESCRIPTION
-UL constants are 32 bit on win64, change to ULL
-change default vendor to NV64 + cuda8
-Advices about AMD env vars